### PR TITLE
Set drupal-core-require-dev constraint as 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
         "se/selenium-server-standalone": "^2.53",
         "dmore/behat-chrome-extension": "^1.0.0",
         "sensiolabs-de/deprecation-detector": "dev-master",
-        "webflo/drupal-core-require-dev": "^8.6.0"
+        "webflo/drupal-core-require-dev": "^8.0"
     }
 }


### PR DESCRIPTION
## Motivation

This package is currently uninstallable with `acquia/blt:9.1` or any site that uses `drupal/core:<8.6.0`. 

## Proposed change

The package `webflo/drupal-core-require-dev` moves in lock-step with changes in `drupal/core` and defines the versions of drupal it works with. There is no need to restrict it 8.6 or higher AFAIK. 

If we un-restrict the version constraint, composer will resolve which version to use with `drupal/core` 
when `webflo/drupal-core-require-dev` is installed. 